### PR TITLE
🔆 Enable color scheme media query

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -10,6 +10,9 @@ module.exports = {
   organizationName: 'acm-uic', // Usually your GitHub org/user name.
   projectName: 'acm-uic.github.io', // Usually your repo name.
   themeConfig: {
+    colorMode: {
+      respectPrefersColorScheme: true,
+    },
     navbar: {
       title: 'ACM@UIC',
       logo: {


### PR DESCRIPTION
Enabling the prefer color scheme media query to respect system color schemes.

Documentation: https://docusaurus.io/docs/api/themes/configuration