### PR TITLE
⌚ Update GoogleCalendarEmbed.tsx to use local timezone

### DIFF
--- a/src/components/GoogleCalendarEmbed/GoogleCalendarEmbed.tsx
+++ b/src/components/GoogleCalendarEmbed/GoogleCalendarEmbed.tsx
@@ -16,7 +16,7 @@ export const GoogleCalendarEmbed: React.FC<GoogleCalendarEmbedProps> = () => {
         <div className="row">
           <iframe
 						className={clsx(styles.calendar)}
-            src="https://calendar.google.com/calendar/embed?src=kc72g1ctfg8b88df34qqb62d1s%40group.calendar.google.com&ctz=America%2FLos_Angeles"
+            src="https://calendar.google.com/calendar/embed?src=kc72g1ctfg8b88df34qqb62d1s%40group.calendar.google.com"
             width="800"
             height="600"
             scrolling="no"


### PR DESCRIPTION
# ⌚ Update GoogleCalendarEmbed.tsx to use local timezone

This PR updates the gcal component to not specify the timezone. (I was wondering why the times looked a bit off... haha.
Without this parameter, the Google calendar will use the user's current timezone.

## How was this tested?

* I was able to locally spin up a dev server and view the embedded calendar iframe on the site.
* Loading the iframe URL directly also displayed the correct time for me.