### PR TITLE
🌟Adding base info for previous SIGs. 

### DIFF
--- a/docs/SIGs/siggame.md
+++ b/docs/SIGs/siggame.md
@@ -1,8 +1,4 @@
----
-sidebar_position: 2
----
-
-# SIGGame
+# SIG Game
 ### Meeting dates are still being decided.
 
 Like to play video games? Ever think about making them? If you answered yes to either of these questions, then SIG Game is the group for you! SIG Game is dedicated to exploring all facets of game development, and to that end provides an environment that parallels that of real-world video game industries. Projects range from group level development to each individual member planning a game from design to implementation, collaborating with each other and critiquing each other's code in a source-controlled environment. Because of this, we offer projects for people of all skill levels! We will mostly cover the game engine Unity, since that is one of the most popular engines out there, and is being used by many prominent developers. Feel free to message one of us with the emails below if you have any questions, and we hope to see you in one of our future meetings!

--- a/docs/SIGs/sigmath.md
+++ b/docs/SIGs/sigmath.md
@@ -1,0 +1,14 @@
+# SIG Math
+
+:::caution
+
+This SIG page is currently under construction! Check back later for more information!
+
+:::
+
+|  <!-- -->   |  <!-- -->                                           |
+|-------------|-----------------------------------------------------|
+| **Weekday** | TBA, attend the ACM GBM to find out!                |
+| **Time**    | TBA, attend the ACM GBM to find out!                |
+| **Location**| Zoom                                                |
+| **Leaders** | Ben Deschand                                        |

--- a/docs/SIGs/sigquantitativetrading.md
+++ b/docs/SIGs/sigquantitativetrading.md
@@ -1,0 +1,31 @@
+# SIG Quantitative Trading
+
+:::caution
+
+This SIG page is currently under construction! Check back later for more information!
+
+:::
+
+|  <!-- -->   |  <!-- -->                                           |
+|-------------|-----------------------------------------------------|
+| **Weekday** | TBA, attend the ACM GBM to find out!                |
+| **Time**    | TBA, attend the ACM GBM to find out!                |
+| **Location**| GroupMe + Hangouts                                  |
+| **Leaders** | Jason Bohne                                         |
+| **Website** | https://www.notion.so/Quantitative-Trading-Club-71a6625b95a144799f04729db7e4e79c |
+
+## Who are we?
+
+Quantitative Trading Club is a student-based organization at the University of Illinois-Chicago with an emphasis on model algorithmic trading. We learn, utilize, and create models from various open-source, cloud-based programs such as QuantConnect, Quantopian, etc. We backtest, paper-trade, and live-trade our models that are impossible to simulate without the help of financial, computer science, and mathematical literacy.
+
+## Leaders
+
+* Jason Bohne
+
+## Contact
+
+**Email Me:** jbohne3@uic.edu or qtcuic@gmail.com
+
+## Additional Resources
+
+* https://www.notion.so/Quantitative-Trading-Club-71a6625b95a144799f04729db7e4e79c

--- a/docs/SIGs/sigsysadmin.md
+++ b/docs/SIGs/sigsysadmin.md
@@ -1,7 +1,3 @@
----
-sidebar_position: 10
----
-
-# SIGSysAdmin
+# SIG SysAdmin
 
 We have a lot of servers.

--- a/docs/SIGs/sigwebdev.md
+++ b/docs/SIGs/sigwebdev.md
@@ -1,0 +1,14 @@
+# SIG WebDev
+
+:::caution
+
+This SIG page is currently under construction! Check back later for more information!
+
+:::
+
+|  <!-- -->   |  <!-- -->                                           |
+|-------------|-----------------------------------------------------|
+| **Weekday** | TBA, attend the ACM GBM to find out!                |
+| **Time**    | TBA, attend the ACM GBM to find out!                |
+| **Location**| ACM Office, SELE 2264, CS Lab SELE 2254, or Discord |
+| **Leaders** | Arshad Narmawala & Clark Chen                       |


### PR DESCRIPTION
# Docs/sig-import: 🌟Adding base info for previous SIGs. 
Adding stub notes of most SIG pages.

## How was this tested?

* This was tested locally using `yarn build`.