### PR TITLE
🔥 remove redundant title from navbar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,6 +19,7 @@ module.exports = {
         src: "img/logo.png",
       },
       items: [
+        { to: "/", label: "Home", position: "left" },
         { to: "/blog", label: "Announcements", position: "left" },
         {
           to: "/sigs/Overview",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -14,9 +14,8 @@ module.exports = {
       respectPrefersColorScheme: true,
     },
     navbar: {
-      title: "ACM@UIC",
       logo: {
-        alt: "ACM@UIC Logo",
+        alt: "ACM@UIC",
         src: "img/logo.png",
       },
       items: [


### PR DESCRIPTION
Site title in the navbar next to the logo seems redundant. We still have it in the `alt` text of the logo incase it does not render.

before: ![image](https://user-images.githubusercontent.com/5100938/132164917-46cd02a9-1913-4916-8659-41bc696d1b0b.png)

after: ![image](https://user-images.githubusercontent.com/5100938/132170101-279f3856-5adc-47d7-84b1-833b12f01af0.png)

