### PR TITLE
🩹 use discord server link from `appConfig` + 🏷 typecheck `.js` config files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,11 @@
+// @ts-check
+
 const OFF = 0;
 const WARNING = 1;
 const ERROR = 2;
 
-module.exports = {
+/** @type {import('eslint').Linter.Config} */
+const config = {
   root: true,
   env: {
     browser: true,
@@ -66,3 +69,5 @@ module.exports = {
     "@typescript-eslint/no-use-before-define": [ERROR, { functions: false, classes: false, variables: true }],
   },
 };
+
+module.exports = config;

--- a/appConfig.js
+++ b/appConfig.js
@@ -1,7 +1,10 @@
-module.exports = {
+// @ts-check
+
+exports.config = {
   googleCalendarApiKey: "AIzaSyAux1TUS49w76siE8B-kO0eoYk6KLQDgOI",
   googleCalendarId: "kc72g1ctfg8b88df34qqb62d1s@group.calendar.google.com",
   googleCalendarLink:
     "https://calendar.google.com/calendar/u/0/embed?src=kc72g1ctfg8b88df34qqb62d1s@group.calendar.google.com",
   discordServerLink: "https://discord.gg/Afy6gf4",
 };
+exports.default = exports.config;

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,8 @@
-module.exports = {
+// @ts-check
+
+/** @type {import('@babel/core').TransformOptions} */
+const config = {
   presets: [require.resolve("@docusaurus/core/lib/babel/preset")],
 };
+
+module.exports = config;

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -46,7 +46,7 @@ module.exports = {
           href: "/join",
         },
         {
-          href: "https://discord.gg/Afy6gf4",
+          href: appConfig.discordServerLink,
           label: "Discord",
           position: "right",
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,8 +1,10 @@
-/** @type {import('@docusaurus/types').DocusaurusConfig} */
+// @ts-check
 
-const appConfig = require.resolve("./appConfig");
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { config: appConfig } = require("./appConfig");
 
-module.exports = {
+/** @type {Partial<import('@docusaurus/types').DocusaurusConfig>} */
+const config = {
   title: "ACM@UIC",
   tagline: "Association for Computing Machinery Student Chapter at University of Illinois at Chicago",
   url: "https://acm-uic.github.io",
@@ -160,3 +162,6 @@ module.exports = {
     ],
   ],
 };
+
+exports.default = config;
+module.exports = config;

--- a/src/components/DiscordLink/DiscordLink.tsx
+++ b/src/components/DiscordLink/DiscordLink.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Link from "@docusaurus/Link";
-import config from "../../../appConfig";
+import { config } from "../../../appConfig";
 
 export type DiscordLinkProps = {
   showLink?: boolean;

--- a/src/components/DiscordRedirect/DiscordRedirect.tsx
+++ b/src/components/DiscordRedirect/DiscordRedirect.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import Head from "@docusaurus/Head";
-import config from "../../../appConfig";
+import { config } from "../../../appConfig";
 
 export type DiscordRedirectProps = {
   delay?: number;

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -3,7 +3,7 @@ import Link from "@docusaurus/Link";
 import useSWR from "swr";
 import Linkify from "react-linkify";
 import { getEvents, CalendarEventDateTime } from "../../util/getEvents";
-import config from "../../../appConfig";
+import { config } from "../../../appConfig";
 
 const ALL_DAY_EVENT = "All Day";
 const A_DAY = 1000 * 3600 * 24;

--- a/src/components/GoogleCalendarEmbed/GoogleCalendarEmbed.tsx
+++ b/src/components/GoogleCalendarEmbed/GoogleCalendarEmbed.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import clsx from "clsx";
 import styles from "./GoogleCalendarEmbed.module.css";
-import config from "../../../appConfig";
+import { config } from "../../../appConfig";
 
 export type GoogleCalendarEmbedProps = Record<string, never>;
 


### PR DESCRIPTION
- Fixed bug where `appConfig` import in `docusaurus.config.js` was undefined.
![image](https://user-images.githubusercontent.com/5100938/133941360-13214ffc-ba86-4e72-bf31-0cf29bcaf07a.png)
- Add typechecking to `.js` config files
- Use navbar discord href from config file.