### PR TITLE
⚙️ add devcontainer config to get submodules after creating instance

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "postCreateCommand": "git submodule update --init"
+}


### PR DESCRIPTION
GitHub codespaces do not fetch the submodules by default. This change adds a command to get the submodules after creating the container. This should improve the developer experience when creating new codespace instances.