### PR TITLE
🌟 Make calendar button more prominent

### DIFF
--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -86,8 +86,10 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = () => {
           </div>
         ))}
       </div>
-      <div className="row">
-        <Link to="/calendar">View calendar</Link>
+      <div className="row row--no-gutters">
+        <div className="margin-top--lg margin-bottom--lg button button--outline button--danger">
+          <Link to="/calendar">View Full calendar</Link>
+        </div>
       </div>
     </div>
   );

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -87,7 +87,7 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = () => {
         ))}
       </div>
       <div className="row row--no-gutters">
-        <div className="margin-top--lg margin-bottom--lg button button--outline button--danger">
+        <div className="margin-top--lg margin-bottom--lg button button--outline button--secondary">
           <Link to="/calendar">View Full calendar</Link>
         </div>
       </div>


### PR DESCRIPTION
Signed-off-by: Soham S Gumaste <sgumas2@uic.edu>

This is just a personal gripe I thought the link to the full ACM calendar should be more prominent.

I tried to get the button to be centered with the cards but its like 3-5px off for some reason I cant find even with inspect element.