### PR TITLE
🐛 fix bold text on /join page

### DIFF
--- a/src/pages/join.mdx
+++ b/src/pages/join.mdx
@@ -29,7 +29,7 @@ If the form give you a permission denied error, please make sure to sign out of 
 
 **Ways to connect with us:**
 
-- <DiscordLink>Join the ACM@UIC Discord Server</DiscordLink> **(Preferred)**
+- <DiscordLink>Join the ACM@UIC Discord Server</DiscordLink> <b>(Preferred)</b>
 - [Sign up for the mailing list](https://acm.cs.uic.edu/mailsignup) (Announce-only or General Discussion)
 - [Follow us on Facebook](http://www.facebook.com/pages/UIC-ACM/78488002212)
 - <SlackSignUpLink>Join ACM's Slack workspace</SlackSignUpLink>


### PR DESCRIPTION
## Description

Fix bold text on /join page.

before:
![image](https://user-images.githubusercontent.com/5100938/139812372-e208d946-c506-4a66-b9d0-718fd9db2fad.png)

after:
![image](https://user-images.githubusercontent.com/5100938/139812352-5b6e3df5-9da7-484e-874a-ae94b8e7a4ed.png)
