### PR TITLE
✨  add discord location parsing to events agenda

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ const config = {
   },
   globals: {
     testStylelintRule: true,
-    JSX: true
+    JSX: true,
   },
   extends: [
     "eslint:recommended",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,6 +19,7 @@ const config = {
   },
   globals: {
     testStylelintRule: true,
+    JSX: true
   },
   extends: [
     "eslint:recommended",

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -54,7 +54,12 @@ const locationFormatter = (discordData: DiscordWidgetApiResponse, location: stri
     const parsedLocation = location.replace(/^Discord ((Voice)|(Stage)):/i, "").trim();
     const channel = discordData.channels.find((c) => c.name.includes(parsedLocation));
     if (channel) {
-      return <Link to={config.discordServerInviteLink}>{channel.name}</Link>;
+      return (
+        <Link to={config.discordServerInviteLink}>
+          <img src="/media/Discord-Logo-Color.svg" alt="Discord" height="20px" style={{ verticalAlign: "text-top" }} />{" "}
+          {channel.name}
+        </Link>
+      );
     }
   }
 

--- a/src/util/getDiscordWidgetApi.ts
+++ b/src/util/getDiscordWidgetApi.ts
@@ -1,0 +1,39 @@
+export type DiscordStatusType = "idle" | "dnd" | "online" | "offline" | "invisbile";
+
+export interface DiscordChannel {
+  id: string;
+  name: string;
+  position: number;
+}
+
+export interface DiscordMember {
+  avatar: string | null;
+  // eslint-disable-next-line camelcase
+  avatar_url: string;
+  discriminator: string;
+  id: string;
+  status: DiscordStatusType;
+  username: string;
+}
+
+export interface DiscordWidgetApiResponse {
+  channels: DiscordChannel[];
+  id: string;
+  // eslint-disable-next-line camelcase
+  instant_invite: string;
+  members: DiscordMember[];
+  name: string;
+  // eslint-disable-next-line camelcase
+  presence_count: number;
+}
+
+/**
+ * Get Discord widget API response for a server.
+ * @param serverId Discord server/guid id
+ * @returns Discord Widget api response
+ */
+export const getDiscordWidgetApi = async (serverId: string): Promise<DiscordWidgetApiResponse> => {
+  const res = await fetch(`https://discord.com/api/guilds/${serverId}/widget.json`);
+  const data = (await res.json()) as DiscordWidgetApiResponse;
+  return data;
+};

--- a/src/util/getEvents.ts
+++ b/src/util/getEvents.ts
@@ -23,7 +23,7 @@ export const getEvents = async (apiKey: string, calendarId: string): Promise<Cal
     key: apiKey,
     timeMin: new Date().toISOString(),
     timeMax: new Date(+Date.now() + A_YEAR).toISOString(),
-    maxResults: "10",
+    maxResults: "9",
     orderBy: "startTime",
   };
   const calendarResponse = await fetch(


### PR DESCRIPTION
## Description

- Add logic to parse event location to show Discord invite link when location starts with "Discord Stage:" or "Discord Voice:".
- Show 9 events (instead of 10). Makes a 3x3 grid on desktop/tablet viewports.
- Bump media submodule to use Discord logo.

![image](https://user-images.githubusercontent.com/5100938/139812613-39051b7f-945f-4589-bf59-946422ecf64f.png)
