### PR TITLE
📝 add discord event parsing docs

### DIFF
--- a/docs/Knowledge Base/calendar-event-location-parsing.md
+++ b/docs/Knowledge Base/calendar-event-location-parsing.md
@@ -1,4 +1,10 @@
-# Calendar Event Location
+---
+slug: /kb/calendar-event-location-parsing
+description: How we parse calendar events location to display events on the website, and sync events to Discord.
+tags: [discord, calendar]
+---
+
+# Calendar Event Location Parsing
 
 We do some special parsing of the location field from a calendar event.
 

--- a/docs/Knowledge Base/calendar-event-location.md
+++ b/docs/Knowledge Base/calendar-event-location.md
@@ -1,0 +1,34 @@
+# Calendar Event Location
+
+We do some special parsing of the location field from a calendar event.
+
+## Website
+
+Repository: [acm-uic/acm-uic.github.io](https://github.com/acm-uic/acm-uic.github.io)
+
+When the event location starts with "Discord Voice:" or "Discord Stage:" followed with the voice or stage channel name
+(example: "Discord Voice: SIG SysAdmin"), the location will be converted to a link (invite link) to the server with the
+text of the voice channel.
+
+Example:
+
+![event with discord voice location displayed on the website](/media/calendar-event-location-website.png)
+![calendar event details with discord voice location](/media/calendar-event-location-gcal.png)
+
+## Discord Events Sync
+
+:::info
+
+This project is under active development.
+
+:::
+
+Repository: [acm-uic/discord-events-sync](https://github.com/acm-uic/discord-events-sync)
+
+The project syncs events from Google calendar to Discord.
+
+It uses the same location prefixing logic
+as the website. Event locations beginning with "Discord Voice:" or "Discord Stage:" will be created and link to the
+appropriate voice channel when syncing.
+
+Events that do not match will include the location as text and Discord event's type will be set to "Somewhere else".


### PR DESCRIPTION
## Description

- Add documentation about calendar event location parsing.
- Related PR: #117 
- Preview link: <https://brave-sea-0f799c410-154.centralus.azurestaticapps.net/docs/kb/calendar-event-location-parsing>

## Issues

None

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
