### PR TITLE
Fix line breaks in /contact

### DIFF
--- a/src/pages/contact.mdx
+++ b/src/pages/contact.mdx
@@ -5,17 +5,17 @@ import SlackSignUpLink from "../components/SlackSignUpLink";
 
 ## Office Location
 
-Association for Computing Machinery
-SEL-E 2264
-950 S Halsted St
+Association for Computing Machinery<br />
+SEL-E 2264<br />
+950 S Halsted St<br />
 Chicago, IL 60607
 
 ## Mailing Address
 
-Association for Computing Machinery
-Department of Computer Science (MC 152)
-Room 1120 Science and Engineering Offices
-851 South Morgan Street
+Association for Computing Machinery<br />
+Department of Computer Science (MC 152)<br />
+Room 1120 Science and Engineering Offices<br />
+851 South Morgan Street<br />
 Chicago, IL 60607-7053, USA
 
 ## Officers Email Address


### PR DESCRIPTION
## Description <!-- Mandatory -->

Fix line breaks in address information on /contact page.

before:
![before-fix](https://user-images.githubusercontent.com/5100938/149650195-814900cd-f026-4197-869c-61f36f4341b7.png)

after:
![after-fix](https://user-images.githubusercontent.com/5100938/149650733-7567a80a-0646-472c-a533-71d49c8a9ccf.png)

## Issues

<!-- Add related issues here. Use closes/fixes prefixes to auto close issues. -->

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
