### PR TITLE
🐛 fix discord icon styles

### DIFF
--- a/src/components/EventsAgenda/EventsAgenda.module.css
+++ b/src/components/EventsAgenda/EventsAgenda.module.css
@@ -1,0 +1,4 @@
+.discordIcon {
+  height: 20px;
+  vertical-align: text-top;
+}

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -2,6 +2,8 @@ import React from "react";
 import Link from "@docusaurus/Link";
 import useSWRImmutable from "swr/immutable";
 import Linkify from "react-linkify";
+import clsx from "clsx";
+import styles from "./EventsAgenda.module.css";
 import { getEvents, CalendarEventDateTime } from "../../util/getEvents";
 import { DiscordWidgetApiResponse, getDiscordWidgetApi } from "../../util/getDiscordWidgetApi";
 import { config } from "../../../appConfig";
@@ -56,8 +58,7 @@ const locationFormatter = (discordData: DiscordWidgetApiResponse, location: stri
     if (channel) {
       return (
         <Link to={config.discordServerInviteLink}>
-          <img src="/media/Discord-Logo-Color.svg" alt="Discord" height="20px" style={{ verticalAlign: "text-top" }} />{" "}
-          {channel.name}
+          <img src="/media/Discord-Logo-Color.svg" alt="Discord" className={clsx(styles.discordIcon)} /> {channel.name}
         </Link>
       );
     }


### PR DESCRIPTION
## Description <!-- Mandatory -->

Fix EventsAgenda component css. Discord icon was too large.

before:
![image](https://user-images.githubusercontent.com/5100938/152916674-51c7a2d9-89f4-4ca6-aac6-537d4d54f901.png)

after:
![image](https://user-images.githubusercontent.com/5100938/152916688-6b66c53b-c21f-45a9-917a-620222ba60c1.png)


## Issues

<!-- Add related issues here. Use closes/fixes prefixes to auto close issues. -->

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
