### PR TITLE
✨  add loading/empty/error state for events agenda component

### DIFF
--- a/src/components/EventsAgenda/EventsAgenda.module.css
+++ b/src/components/EventsAgenda/EventsAgenda.module.css
@@ -2,3 +2,27 @@
   height: 20px;
   vertical-align: text-top;
 }
+
+.eventCard {
+  height: calc(100% - 16px);
+  padding-bottom: 16px;
+}
+
+.eventsOverlay {
+  position: absolute;
+  width: 100%;
+  top: 0;
+  left: 0;
+  height: 100%;
+  backdrop-filter: blur(4px) saturate(30%);
+  font-weight: 500;
+  font-size: 1.3em;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.eventsRow {
+  position: relative;
+}

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -160,7 +160,7 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
         {!eventsError && !eventsData && new Array(numItems).fill(0).map(() => <EventsAgendaEmptyItem />)}
 
         {/* EMPTY STATE */}
-        {!eventsError && eventsData && eventsData.items.length === 0 && (
+        {!eventsError && eventsData && eventsData.items?.length === 0 && (
           <>
             <EventsAgendaEmpty />
             {new Array(numItems).fill(0).map(() => (
@@ -172,8 +172,8 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
         {/* VALID DATA */}
         {!eventsError &&
           eventsData &&
-          eventsData.items.length !== 0 &&
-          eventsData.items.map((event) => <EventsAgendaItem event={event} discordData={discordData} />)}
+          eventsData.items?.length !== 0 &&
+          eventsData.items?.map((event) => <EventsAgendaItem event={event} discordData={discordData} />)}
       </div>
       <div className="row row--no-gutters">
         <div className="margin-top--lg margin-bottom--lg button button--outline button--secondary">

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -138,6 +138,8 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
     console.error("error while getting discord data", discordData);
   }
 
+  const renderEmptyItems = () => new Array(numItems).fill(0).map((_, index) => <EventsAgendaEmptyItem key={`empty-event-${index}`} />);
+
   return (
     <div className={clsx(styles.eventsContainer, "container")}>
       <div className="row">
@@ -150,22 +152,18 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
         {eventsError && (
           <>
             <EventsAgendaError />
-            {new Array(numItems).fill(0).map(() => (
-              <EventsAgendaEmptyItem />
-            ))}
+            {renderEmptyItems()}
           </>
         )}
 
         {/* LOADING STATE */}
-        {!eventsError && !eventsData && new Array(numItems).fill(0).map(() => <EventsAgendaEmptyItem />)}
+        {!eventsError && !eventsData && renderEmptyItems()}
 
         {/* EMPTY STATE */}
         {!eventsError && eventsData && eventsData.items?.length === 0 && (
           <>
             <EventsAgendaEmpty />
-            {new Array(numItems).fill(0).map(() => (
-              <EventsAgendaEmptyItem />
-            ))}
+            {renderEmptyItems()}
           </>
         )}
 
@@ -173,7 +171,7 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
         {!eventsError &&
           eventsData &&
           eventsData.items?.length !== 0 &&
-          eventsData.items?.map((event) => <EventsAgendaItem event={event} discordData={discordData} />)}
+          eventsData.items?.map((event, index) => <EventsAgendaItem key={`${index}-${event?.id}`} event={event} discordData={discordData} />)}
       </div>
       <div className="row row--no-gutters">
         <div className="margin-top--lg margin-bottom--lg button button--outline button--secondary">

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -4,14 +4,21 @@ import useSWRImmutable from "swr/immutable";
 import Linkify from "react-linkify";
 import clsx from "clsx";
 import styles from "./EventsAgenda.module.css";
-import { getEvents, CalendarEventDateTime } from "../../util/getEvents";
+import { getEvents, CalendarEventDateTime, CalendarEvent } from "../../util/getEvents";
 import { DiscordWidgetApiResponse, getDiscordWidgetApi } from "../../util/getDiscordWidgetApi";
 import { config } from "../../../appConfig";
+import { ShimmerLine } from "../Shimmer";
 
 const ALL_DAY_EVENT = "All Day";
 const A_DAY = 1000 * 3600 * 24;
 
-export type EventsAgendaProps = Record<string, never>;
+export type EventsAgendaProps = {
+  /**
+   * Number of events to show
+   * @default 9
+   */
+  numItems?: number;
+};
 
 const timePeriodFormatter = (start: CalendarEventDateTime, end: CalendarEventDateTime): string => {
   const datesAreOnSameDay = (first: Date, second: Date): boolean =>
@@ -67,7 +74,54 @@ const locationFormatter = (discordData: DiscordWidgetApiResponse, location: stri
   return <Linkify>📍 {location}</Linkify>;
 };
 
-export const EventsAgenda: React.FC<EventsAgendaProps> = () => {
+interface EventsAgendaItemProps {
+  event: CalendarEvent;
+  discordData?: DiscordWidgetApiResponse;
+}
+
+const EventsAgendaItem: React.FC<EventsAgendaItemProps> = ({ event, discordData }) => (
+  <div className="col col--4">
+    <div className={clsx(styles.eventCard, "card margin--xs")}>
+      <div className="card__header">
+        <h3>{event.summary}</h3>
+      </div>
+      <div className="card__body">
+        <div>⌚ {timePeriodFormatter(event.start, event.end)}</div>
+        {event.location && (
+          <div>
+            {!discordData ? <Linkify>📍 {event.location}</Linkify> : locationFormatter(discordData, event.location)}
+          </div>
+        )}
+      </div>
+    </div>
+  </div>
+);
+
+const EventsAgendaEmptyItem: React.FC = () => (
+  <div className="col col--4">
+    <div className={clsx(styles.eventCard, "card margin--xs")}>
+      <div className="card__header">
+        <h3>
+          <ShimmerLine />
+        </h3>
+      </div>
+      <div className="card__body">
+        <div>
+          ⌚ <ShimmerLine />
+        </div>
+        <div>
+          📍 <ShimmerLine />
+        </div>
+      </div>
+    </div>
+  </div>
+);
+
+const EventsAgendaError: React.FC = () => <div className={clsx(styles.eventsOverlay)}>💀 Could not load events</div>;
+
+const EventsAgendaEmpty: React.FC = () => <div className={clsx(styles.eventsOverlay)}>🍹 No upcoming events</div>;
+
+export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
   const { data: eventsData, error: eventsError } = useSWRImmutable("/events", () =>
     getEvents(config.googleCalendarApiKey, config.googleCalendarId)
   );
@@ -78,42 +132,48 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = () => {
 
   if (eventsError) {
     console.error("error while getting calendar data", eventsError);
-    return null;
   }
-  if (!eventsData || !eventsData.items) {
-    console.error("no calendar data returned");
-    return null;
+
+  if (discordError) {
+    console.error("error while getting discord data", discordData);
   }
 
   return (
-    <div className="container">
+    <div className={clsx(styles.eventsContainer, "container")}>
       <div className="row">
         <div className="col text--center">
           <h2>📅 Upcoming Events</h2>
         </div>
       </div>
-      <div className="row">
-        {eventsData.items.map((event, eventIndex) => (
-          <div className="col col--4" key={`${eventIndex}-${event.id}`}>
-            <div className="card margin--xs">
-              <div className="card__header">
-                <h3>{event.summary}</h3>
-              </div>
-              <div className="card__body">
-                <div>⌚ {timePeriodFormatter(event.start, event.end)}</div>
-                {event.location && (
-                  <div>
-                    {discordError || !discordData ? (
-                      <Linkify>📍 {event.location}</Linkify>
-                    ) : (
-                      locationFormatter(discordData, event.location)
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        ))}
+      <div className={clsx(styles.eventsRow, "row")}>
+        {/* ERROR STATE */}
+        {eventsError && !eventsData && (
+          <>
+            <EventsAgendaError />
+            {new Array(numItems).fill(0).map(() => (
+              <EventsAgendaEmptyItem />
+            ))}
+          </>
+        )}
+
+        {/* LOADING STATE */}
+        {!eventsError && !eventsData && new Array(numItems).fill(0).map(() => <EventsAgendaEmptyItem />)}
+
+        {/* EMPTY STATE */}
+        {!eventsError && eventsData && eventsData.items.length === 0 && (
+          <>
+            <EventsAgendaEmpty />
+            {new Array(numItems).fill(0).map(() => (
+              <EventsAgendaEmptyItem />
+            ))}
+          </>
+        )}
+
+        {/* VALID DATA */}
+        {!eventsError &&
+          eventsData &&
+          eventsData.items.length !== 0 &&
+          eventsData.items.map((event) => <EventsAgendaItem event={event} discordData={discordData} />)}
       </div>
       <div className="row row--no-gutters">
         <div className="margin-top--lg margin-bottom--lg button button--outline button--secondary">

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -138,7 +138,8 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
     console.error("error while getting discord data", discordData);
   }
 
-  const renderEmptyItems = () => new Array(numItems).fill(0).map((_, index) => <EventsAgendaEmptyItem key={`empty-event-${index}`} />);
+  const renderEmptyItems = () =>
+    new Array(numItems).fill(0).map((_, index) => <EventsAgendaEmptyItem key={`empty-event-${index}`} />);
 
   return (
     <div className={clsx(styles.eventsContainer, "container")}>
@@ -171,7 +172,9 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
         {!eventsError &&
           eventsData &&
           eventsData.items?.length !== 0 &&
-          eventsData.items?.map((event, index) => <EventsAgendaItem key={`${index}-${event?.id}`} event={event} discordData={discordData} />)}
+          eventsData.items?.map((event, index) => (
+            <EventsAgendaItem key={`${index}-${event?.id}`} event={event} discordData={discordData} />
+          ))}
       </div>
       <div className="row row--no-gutters">
         <div className="margin-top--lg margin-bottom--lg button button--outline button--secondary">

--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -147,7 +147,7 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
       </div>
       <div className={clsx(styles.eventsRow, "row")}>
         {/* ERROR STATE */}
-        {eventsError && !eventsData && (
+        {eventsError && (
           <>
             <EventsAgendaError />
             {new Array(numItems).fill(0).map(() => (

--- a/src/components/Shimmer/ShimmerLine.module.css
+++ b/src/components/Shimmer/ShimmerLine.module.css
@@ -28,3 +28,15 @@
     background-position: 468px 0;
   }
 }
+
+@media (prefers-reduced-motion) {
+  @keyframes placeholderShimmer {
+    0% {
+      background-position: 0 0;
+    }
+
+    100% {
+      background-position: 0 0;
+    }
+  }
+}

--- a/src/components/Shimmer/ShimmerLine.module.css
+++ b/src/components/Shimmer/ShimmerLine.module.css
@@ -1,0 +1,30 @@
+.shine {
+  background: #f6f7f8;
+  background-image: linear-gradient(to right, #f6f7f8 0%, #edeef1 20%, #f6f7f8 40%, #f6f7f8 100%);
+  background-repeat: no-repeat;
+  background-size: 800px 104px;
+  display: inline-block;
+  position: relative;
+  animation-duration: 1s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: placeholderShimmer;
+  animation-timing-function: linear;
+}
+
+.lines {
+  height: 1em;
+  margin-top: 10px;
+  width: calc(100% - 50px);
+  display: inline-block;
+}
+
+@keyframes placeholderShimmer {
+  0% {
+    background-position: -468px 0;
+  }
+
+  100% {
+    background-position: 468px 0;
+  }
+}

--- a/src/components/Shimmer/ShimmerLine.tsx
+++ b/src/components/Shimmer/ShimmerLine.tsx
@@ -1,0 +1,5 @@
+import * as React from "react";
+import clsx from "clsx";
+import styles from "./ShimmerLine.module.css";
+
+export const ShimmerLine: React.FC = () => <span className={clsx(styles.lines, styles.shine)} />;

--- a/src/components/Shimmer/index.ts
+++ b/src/components/Shimmer/index.ts
@@ -1,0 +1,1 @@
+export * from "./ShimmerLine";

--- a/src/util/getEvents.ts
+++ b/src/util/getEvents.ts
@@ -10,6 +10,11 @@ export type CalendarEventsResponse = gapi.client.calendar.Events;
  */
 const A_YEAR = 1000 * 3600 * 24 * 365;
 
+class GetEventsError extends Error {
+  response: Response;
+  status: number;
+}
+
 /**
  * Get events list for a specific calendar from google calendar api.
  * Events in the past and a year from "now" are filtered and recurring events are expanded into single events.
@@ -31,6 +36,12 @@ export const getEvents = async (apiKey: string, calendarId: string): Promise<Cal
       calendarRequestParams
     ).toString()}`
   );
+  if (!calendarResponse.ok) {
+    const err = new GetEventsError(`HTTP status code: ${  calendarResponse.status}`);
+    err.response = calendarResponse;
+    err.status = calendarResponse.status;
+    throw err;
+  }
   const calendarData = await calendarResponse.json();
   return calendarData;
 };

--- a/src/util/getEvents.ts
+++ b/src/util/getEvents.ts
@@ -37,7 +37,7 @@ export const getEvents = async (apiKey: string, calendarId: string): Promise<Cal
     ).toString()}`
   );
   if (!calendarResponse.ok) {
-    const err = new GetEventsError(`HTTP status code: ${  calendarResponse.status}`);
+    const err = new GetEventsError(`HTTP status code: ${calendarResponse.status}`);
     err.response = calendarResponse;
     err.status = calendarResponse.status;
     throw err;


### PR DESCRIPTION
## Description <!-- Mandatory -->

Add empty event items to reduce layout reflow when calendar events are loaded.
Add error, loading, empty state for calendar events.

| | Before | After |
| --- | ------ | ------|
|loading (gif) |![events-loading-before](https://user-images.githubusercontent.com/5100938/155032546-096073d0-c0c7-4660-ad2b-3f667b37c35e.gif) |![events-loading-after](https://user-images.githubusercontent.com/5100938/155032685-dfbdf257-53e5-414c-a21d-a7558a60da88.gif) |
|error | N/A | ![error-events-after](https://user-images.githubusercontent.com/5100938/155032182-ded9a413-159e-49e9-afed-ee0fc01ebdad.png)
|empty | ![image](https://user-images.githubusercontent.com/5100938/155032732-56a7d568-1767-481e-a46e-857861d17779.png) | ![no-events-after](https://user-images.githubusercontent.com/5100938/155032183-2759909c-a2ee-4d0c-8667-de21238fae41.png) |


## Issues

N/A

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
