### PR TITLE
don't show updated date and author

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -222,8 +222,6 @@ const config = {
           routeBasePath: "docs",
           sidebarPath: require.resolve("./src/sidebars/docsSidebar.js"),
           editUrl: `${gitHubRepoUrl}/edit/${gitHubRepoDefaultBranch}/`,
-          showLastUpdateTime: true,
-          showLastUpdateAuthor: true,
         },
         blog: {
           showReadingTime: true,


### PR DESCRIPTION
## Description <!-- Mandatory -->

Don't show updated date and author on docs. This date can be misleading because it is based on the latest build and not when the file was updated.

## Issues

<!-- Add related issues here. Use closes/fixes prefixes to auto close issues. -->

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
