### PR TITLE
Adding SIG SysAdmin presentations since October 3, 2022

### DIFF
--- a/SIGs/Active/sigsysadmin.mdx
+++ b/SIGs/Active/sigsysadmin.mdx
@@ -37,6 +37,7 @@ Want to be a SysAdmin? Let your interest be known by contacting an ACM Officer!
 | ------------------------- | --------------------------------------------------------------- |
 | **Email us**              | sigsysadmin AT acm.cs.uic.edu                                   |
 | **Join our mailing list** | Send an blank email to: sigsysadmin-subscribe AT acm.cs.uic.edu |
+| **Chat with us**          | #sig-sysadmin on ACM's Discord                                  |
 
 ## Additional Resources
 
@@ -47,6 +48,15 @@ Want to be a SysAdmin? Let your interest be known by contacting an ACM Officer!
 ## Meeting Notes
 
 [Link to presentations folder](https://drive.google.com/drive/folders/0BxDVEKn0XtfOeGZkY3d0QW1Mdjg?resourcekey=0-F4uEf8N9aduqIkIxqNk51A)
+
+
+### Fall 2022
+
+[9/19/2022 - Intro to SysAdmin](https://docs.google.com/presentation/d/1KyohhMGaDF7d_Zby0IHDOyMSsrvWorwqROotURiWZgw/edit?usp=sharing)
+
+[10/3/2022 - Learn You a Great Automation for Great Good](https://docs.google.com/presentation/d/1YTAbnIXu6_wDQRmm0eZEoHq-74F1AYM52BxBWLxoRZ4/edit?usp=sharing)
+
+[10/3/2022 - Monitor Wall Status](https://docs.google.com/presentation/d/10lvxE9nWVGhsILYhG9dSiONY51pT0_u80wpPnck1tbA/edit?usp=sharing)
 
 ### Spring 2022
 

--- a/SIGs/Active/sigsysadmin.mdx
+++ b/SIGs/Active/sigsysadmin.mdx
@@ -11,7 +11,7 @@ import DiscordLink from "../../src/components/DiscordLink";
 | **Weekday**  | Tuesdays                                                                       |
 | **Time**     | 5:30 PM                                                                        |
 | **Location** | ACM Office, SELE 2264, CS Lab SELE 2254, or <DiscordLink>Discord</DiscordLink> |
-| **Leaders**  | Chase Lee & Christian Bingman                                                  |
+| **Leaders**  | Chase Lee, Christian Bingman, Soham Gumaste                                    |
 
 ## About
 

--- a/SIGs/Active/sigsysadmin.mdx
+++ b/SIGs/Active/sigsysadmin.mdx
@@ -49,7 +49,6 @@ Want to be a SysAdmin? Let your interest be known by contacting an ACM Officer!
 
 [Link to presentations folder](https://drive.google.com/drive/folders/0BxDVEKn0XtfOeGZkY3d0QW1Mdjg?resourcekey=0-F4uEf8N9aduqIkIxqNk51A)
 
-
 ### Fall 2022
 
 [9/19/2022 - Intro to SysAdmin](https://docs.google.com/presentation/d/1KyohhMGaDF7d_Zby0IHDOyMSsrvWorwqROotURiWZgw/edit?usp=sharing)


### PR DESCRIPTION
## Adding SIG SysAdmin presentations since October 3, 2022

Updates the SIG SysAdmin page with more presentation information.

## Issues

N/A

## Checklist

- [x] I've labeled the PR appropriately.
- [ ] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
