### PR TITLE
✨ stop shimmering animation when events fail to load

### DIFF
--- a/src/components/EventsAgenda/EventsAgenda.tsx
+++ b/src/components/EventsAgenda/EventsAgenda.tsx
@@ -7,7 +7,7 @@ import styles from "./EventsAgenda.module.css";
 import { getEvents, CalendarEventDateTime, CalendarEvent } from "../../util/getEvents";
 import { DiscordWidgetApiResponse, getDiscordWidgetApi } from "../../util/getDiscordWidgetApi";
 import { config } from "../../../appConfig";
-import { ShimmerLine } from "../Shimmer";
+import { ShimmerLine, ShimmerLineProps } from "../Shimmer";
 
 const ALL_DAY_EVENT = "All Day";
 const A_DAY = 1000 * 3600 * 24;
@@ -97,20 +97,22 @@ const EventsAgendaItem: React.FC<EventsAgendaItemProps> = ({ event, discordData 
   </div>
 );
 
-const EventsAgendaEmptyItem: React.FC = () => (
+type EventsAgendaEmptyItemProps = ShimmerLineProps;
+
+const EventsAgendaEmptyItem: React.FC<EventsAgendaEmptyItemProps> = ({ animate }) => (
   <div className="col col--4">
     <div className={clsx(styles.eventCard, "card margin--xs")}>
       <div className="card__header">
         <h3>
-          <ShimmerLine />
+          <ShimmerLine animate={animate} />
         </h3>
       </div>
       <div className="card__body">
         <div>
-          ⌚ <ShimmerLine />
+          ⌚ <ShimmerLine animate={animate} />
         </div>
         <div>
-          📍 <ShimmerLine />
+          📍 <ShimmerLine animate={animate} />
         </div>
       </div>
     </div>
@@ -138,8 +140,10 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
     console.error("error while getting discord data", discordData);
   }
 
-  const renderEmptyItems = () =>
-    new Array(numItems).fill(0).map((_, index) => <EventsAgendaEmptyItem key={`empty-event-${index}`} />);
+  const renderEmptyItems = (animate?: ShimmerLineProps["animate"]) =>
+    new Array(numItems)
+      .fill(0)
+      .map((_, index) => <EventsAgendaEmptyItem key={`empty-event-${index}`} animate={animate} />);
 
   return (
     <div className={clsx(styles.eventsContainer, "container")}>
@@ -153,7 +157,7 @@ export const EventsAgenda: React.FC<EventsAgendaProps> = ({ numItems = 9 }) => {
         {eventsError && (
           <>
             <EventsAgendaError />
-            {renderEmptyItems()}
+            {renderEmptyItems(false)}
           </>
         )}
 

--- a/src/components/Shimmer/ShimmerLine.module.css
+++ b/src/components/Shimmer/ShimmerLine.module.css
@@ -5,11 +5,6 @@
   background-size: 800px 104px;
   display: inline-block;
   position: relative;
-  animation-duration: 1s;
-  animation-fill-mode: forwards;
-  animation-iteration-count: infinite;
-  animation-name: placeholderShimmer;
-  animation-timing-function: linear;
 }
 
 .lines {
@@ -17,6 +12,14 @@
   margin-top: 10px;
   width: calc(100% - 50px);
   display: inline-block;
+}
+
+.shineAnimation {
+  animation-duration: 1s;
+  animation-fill-mode: forwards;
+  animation-iteration-count: infinite;
+  animation-name: placeholderShimmer;
+  animation-timing-function: linear;
 }
 
 @keyframes placeholderShimmer {

--- a/src/components/Shimmer/ShimmerLine.tsx
+++ b/src/components/Shimmer/ShimmerLine.tsx
@@ -2,4 +2,14 @@ import * as React from "react";
 import clsx from "clsx";
 import styles from "./ShimmerLine.module.css";
 
-export const ShimmerLine: React.FC = () => <span className={clsx(styles.lines, styles.shine)} />;
+export interface ShimmerLineProps {
+  /**
+   * Show shimmer animation
+   * @default true
+   */
+  animate?: boolean;
+}
+
+export const ShimmerLine: React.FC<ShimmerLineProps> = ({ animate = true }) => (
+  <span className={clsx(styles.lines, styles.shine, animate && styles.shineAnimation)} />
+);


### PR DESCRIPTION
## Description <!-- Mandatory -->

stop shimmering animation when events fail to load

it was distracting to see the shimmer animation in the background of the events error state.

## Issues

<!-- Add related issues here. Use closes/fixes prefixes to auto close issues. -->

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
