### PR TITLE
🐛 fix docusaurus deprecated config warning

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,7 +36,11 @@ const config = {
   url: gitHubPagesUrl,
   baseUrl: "/",
   onBrokenLinks: "throw",
-  onBrokenMarkdownLinks: "warn",
+  markdown: {
+    hooks: {
+      onBrokenMarkdownLinks: "warn",
+    },
+  },
   favicon: "img/favicon.png",
   organizationName: gitHubOrg,
   projectName: gitHubRepoName, // Usually your repo name.


### PR DESCRIPTION
## Description

```
[WARNING] The `siteConfig.onBrokenMarkdownLinks` config option is deprecated and will be removed in Docusaurus v4.
Please migrate and move this option to `siteConfig.markdown.hooks.onBrokenMarkdownLinks` instead.
```

## Issues

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
