### PR TITLE
🧹 pnpm approve-builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+ignoredBuiltDependencies:
+  - core-js
+  - core-js-pure
+  - typesense-instantsearch-adapter


### PR DESCRIPTION
## Description

```
╭ Warning ─────────────────────────────────────────────────────────────────────╮
│                                                                              │
│   Ignored build scripts: core-js-pure@3.48.0, core-js@3.48.0,                │
│   typesense-instantsearch-adapter@2.9.0.                                     │
│   Run "pnpm approve-builds" to pick which dependencies should be allowed     │
│   to run scripts.                                                            │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

These post install scripts are not needed by the build of this project.
Setup pnpm workspace config to ignore the build and mitigate the warning.

## Issues

## Checklist

- [x] I've labeled the PR appropriately.
- [x] I've have built the website and verified that my changes work.
- [x] I've linked the appropriate issues and related PRs.
